### PR TITLE
np.bool deprecated

### DIFF
--- a/src/lib.py
+++ b/src/lib.py
@@ -124,7 +124,7 @@ def draw_examples(name, examples, display_values=False):
 
 
 _tinygrad_to_numpy_dtype = {
-  dtypes.bool: np.bool,
+  dtypes.bool: np.bool_,
   dtypes.int32: np.int32,
   dtypes.float32: np.float32,
 }
@@ -173,7 +173,7 @@ def _spec(draw, x, min_size=1):
       arrays(
         shape=shape,
         dtype=dtype,
-        elements=None if dtype is np.bool else integers(min_value=-5, max_value=5),
+        elements=None if dtype is np.bool_ else integers(min_value=-5, max_value=5),
         unique=False,
       )
     )

--- a/src/lib.py
+++ b/src/lib.py
@@ -173,7 +173,7 @@ def _spec(draw, x, min_size=1):
       arrays(
         shape=shape,
         dtype=dtype,
-        elements=None if dtype is np.bool_ else integers(min_value=-5, max_value=5),
+        elements=None if dtype is bool else integers(min_value=-5, max_value=5),
         unique=False,
       )
     )

--- a/src/lib.py
+++ b/src/lib.py
@@ -124,7 +124,7 @@ def draw_examples(name, examples, display_values=False):
 
 
 _tinygrad_to_numpy_dtype = {
-  dtypes.bool: np.bool_,
+  dtypes.bool: bool,
   dtypes.int32: np.int32,
   dtypes.float32: np.float32,
 }


### PR DESCRIPTION
Noticed that the `bool` is actually the only type that works here.  Pretty cumbersome, it seems that the best practice is to just use `bool`. 